### PR TITLE
copy not imported in ml __init__

### DIFF
--- a/pyrsgis/ml/__init__.py
+++ b/pyrsgis/ml/__init__.py
@@ -1,5 +1,6 @@
 #pyrsgis/ml
 
+import copy
 from copy import deepcopy
 import numpy as np
 from ..raster import read


### PR DESCRIPTION
To import copy in __init__  in ml file to avoid error when doing multi-class supervised landcover classification